### PR TITLE
Specify namespace in clusterrolebinding for sa

### DIFF
--- a/charts/logmetrics/templates/clusterrolebinding.yaml
+++ b/charts/logmetrics/templates/clusterrolebinding.yaml
@@ -8,6 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "logmetrics.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ include "logmetrics.rbacName" . }}


### PR DESCRIPTION
Namespace attribute is required when deploying to non-default namespace.